### PR TITLE
Travis build and test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 jdk:
- - openjdk8
+ # openjdk8 is not available on travis-ci.org yet
  - oraclejdk8
  - openjdk7
  - oraclejdk7
+
+sudo: false

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.dynalang</groupId>
   <artifactId>dynalink</artifactId>
   <name>Dynalink</name>
-  <version>0.7</version>
+  <version>0.8-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Dynalink is an invokedynamic-based high-level linking and metaobject protocol library. It enables creation of languages on the JVM that can easily interoperate with plain Java objects and each other.</description>
   <url>http://szegedi.github.com/dynalink</url>
@@ -129,6 +129,7 @@
 	  <groupId>org.ow2.asm</groupId>
 	  <artifactId>asm</artifactId>
 	  <version>4.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/org/dynalang/dynalink/beans/OverloadedMethod.java
+++ b/src/main/java/org/dynalang/dynalink/beans/OverloadedMethod.java
@@ -91,7 +91,10 @@ class OverloadedMethod {
         varArgMethods = new ArrayList<>(methodHandles.size());
         final int argNum = callSiteType.parameterCount();
         for(MethodHandle mh: methodHandles) {
-            mh = mh.asType(mh.type().changeReturnType(commonRetType));
+            MethodType newType = mh.type().changeReturnType(commonRetType);
+            if (!mh.type().equals(newType)) {
+                mh = mh.asType(newType);
+            }
             if(mh.isVarargsCollector()) {
                 final MethodHandle asFixed = mh.asFixedArity();
                 if(argNum == asFixed.type().parameterCount()) {

--- a/src/test/java/org/dynalang/dynalink/beans/TestCompositeOperations.java
+++ b/src/test/java/org/dynalang/dynalink/beans/TestCompositeOperations.java
@@ -85,8 +85,8 @@ public class TestCompositeOperations extends TestCase {
     public static class HashMapWithProperty extends HashMap<Object, Object> {
         private Object color;
 
-        public void setColor(Object color) {
-            this.color = color;
+        public Object setColor(Object color) {
+            return this.color = color;
         }
 
         public Object getColor() {
@@ -127,8 +127,8 @@ public class TestCompositeOperations extends TestCase {
     public static class ArrayListWithProperty extends ArrayList<Object> {
         private Object color;
 
-        public void setColor(Object color) {
-            this.color = color;
+        public Object setColor(Object color) {
+            return this.color = color;
         }
 
         public Object getColor() {

--- a/src/test/java/org/dynalang/dynalink/beans/TestPropertySetter.java
+++ b/src/test/java/org/dynalang/dynalink/beans/TestPropertySetter.java
@@ -104,8 +104,8 @@ public class TestPropertySetter extends TestCase {
     public static class T1 {
         private Object foo;
 
-        public void setFoo(String foo) {
-            this.foo = foo;
+        public Object setFoo(String foo) {
+            return this.foo = foo;
         }
     }
 
@@ -113,12 +113,12 @@ public class TestPropertySetter extends TestCase {
         private Object foo;
         private Object bar;
 
-        public void setFoo(Object foo) {
-            this.foo = foo;
+        public Object setFoo(Object foo) {
+            return this.foo = foo;
         }
 
-        public void setBar(Object... args) {
-            this.bar = args[0];
+        public Object setBar(Object... args) {
+            return this.bar = args[0];
         }
 
         public void setBar(int x) {


### PR DESCRIPTION
Hi Attila,

I did a few simple changes:
- bumped to a new SNAPSHOT version (0.8-SNAPSHOT is the next I guess)
- moved asm to test scope (end users don't need this, only the tests afaik)
- removed openjdk8 from .travis.yml (this version is not available on travis)
Travis link to the build: https://travis-ci.org/bonifaido/dynalink/builds/47967619

However when running the tests on JDK7(u75) and JDK8(u31) I had encountered some failures.
- In TestCompositeOperations the Object return type is mandatory so I made the dummy class return the set value.
- In TestPropertySetter I did the same, however it looked strange to me why a setter needs a return type (?)
- The interesting part is that TestOverloadedDynamicMethod::testStringFormat works on JDK8 but not on JDK7 because the behavior of MethodHandle.asType() is different between the two VMs. JDK 8 does a fastpath when the types are the same, however JDK7 doesn't, so it returns a new MethodHandle which is different from the original one. I have added a manual fastpath so the tests passed. If this difference is an issue or not, I think I need your guidance on that.

The changes are not for actual pulling just for showing what I tried to accomplish.

